### PR TITLE
Fix UnicodeDecodeError on Windows (GBK locale)

### DIFF
--- a/api/infra/db/sqlite.py
+++ b/api/infra/db/sqlite.py
@@ -50,7 +50,7 @@ async def create_pool(db_path: str) -> aiosqlite.Connection:
     db.row_factory = None
     await db.execute("PRAGMA journal_mode=WAL")
     await db.execute("PRAGMA foreign_keys=ON")
-    schema = _SCHEMA_PATH.read_text()
+    schema = _SCHEMA_PATH.read_text(encoding='utf-8')
     await db.executescript(schema)
     await db.commit()
     return db

--- a/mcp/vaultfs/sqlite.py
+++ b/mcp/vaultfs/sqlite.py
@@ -55,7 +55,7 @@ class SqliteVaultFS(VaultFS):
         await _db.execute("PRAGMA journal_mode=WAL")
         await _db.execute("PRAGMA foreign_keys=ON")
         if _SCHEMA_PATH.exists():
-            await _db.executescript(_SCHEMA_PATH.read_text())
+            await _db.executescript(_SCHEMA_PATH.read_text(encoding='utf-8'))
             await _db.commit()
         logger.info("SQLite initialized: %s", db_path)
 


### PR DESCRIPTION
## Summary

Fixes `UnicodeDecodeError: gbk codec cant decode byte 0x94` when running LLM Wiki on Windows with GBK locale.

## Changes

- `api/infra/db/sqlite.py`: Added explicit `encoding=utf-8` to `read_text()` call in `create_pool()`
- `mcp/vaultfs/sqlite.py`: Added explicit `encoding=utf-8` to `read_text()` call in `SqliteVaultFS.init()`

## Why

On Windows, the default file encoding can be GBK/CP936 instead of UTF-8. When the schema file (which is UTF-8) is read using the default encoding, it fails to decode special characters.

## Testing

Verified on Windows 10 with GBK locale - API server and MCP server now start correctly.

?? Generated with [Claude Code](https://claude.com/claude-code)