### PR TITLE
Chunk text files added via filesystem so they're searchable via FTS

### DIFF
--- a/api/domain/watcher.py
+++ b/api/domain/watcher.py
@@ -118,6 +118,27 @@ def _get_source_kind(relative_path: str) -> str:
     return "source"
 
 
+async def _chunk_text_file(db: aiosqlite.Connection, doc_id: str, content: str) -> None:
+    """Chunk a text document's content and (re)populate document_chunks.
+
+    Replaces any existing chunks for the document so re-indexes stay in sync.
+    The chunks_fts triggers on document_chunks keep the FTS5 index current
+    automatically — no extra work needed here.
+    """
+    if not content or not content.strip():
+        return
+    from services.chunker import chunk_text
+    chunks = chunk_text(content)
+    await db.execute("DELETE FROM document_chunks WHERE document_id = ?", (doc_id,))
+    for c in chunks:
+        await db.execute(
+            "INSERT INTO document_chunks (id, document_id, chunk_index, content, page, "
+            "start_char, token_count, header_breadcrumb) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), doc_id, c.index, c.content, c.page,
+             c.start_char, c.token_count, c.header_breadcrumb),
+        )
+
+
 async def _index_file(db: aiosqlite.Connection, workspace: Path, file_path: Path) -> None:
     """Index or re-index a single file."""
     relative = str(file_path.relative_to(workspace))
@@ -173,6 +194,10 @@ async def _index_file(db: aiosqlite.Connection, workspace: Path, file_path: Path
         )
         await db.commit()
         logger.info("Re-indexed (modified): %s", relative)
+        # Re-chunk text files so FTS reflects the new content
+        if content is not None and ext in TEXT_EXTENSIONS:
+            await _chunk_text_file(db, doc_id, content)
+            await db.commit()
         # Re-process non-text files
         if ext not in TEXT_EXTENSIONS and ext:
             from domain.local_processor import process_document as _process
@@ -207,6 +232,12 @@ async def _index_file(db: aiosqlite.Connection, workspace: Path, file_path: Path
             asyncio.create_task(_process(db, doc_id, workspace))
 
     await db.commit()
+
+    # Chunk text files immediately so they're searchable via FTS.
+    # (Non-text files chunk asynchronously via process_document above.)
+    if content is not None and ext in TEXT_EXTENSIONS:
+        await _chunk_text_file(db, doc_id, content)
+        await db.commit()
 
 
 async def _remove_file(db: aiosqlite.Connection, workspace: Path, file_path: Path) -> None:


### PR DESCRIPTION
Fixes #47.

## Problem

When `.md` / `.txt` (or any other `TEXT_EXTENSIONS` file) lands in the workspace via the filesystem — rsync, a scraper, a batch ASR producing transcript sidecars, `git clone`, etc. — the watcher reads the content into `documents.content` but never calls the chunker. `process_document` only runs for files with `status='pending'` (non-TEXT formats like PDF / Office), so the TEXT branch silently skips chunking. Because `chunks_fts` is populated from `document_chunks` (via `chunks_fts_insert` trigger), those documents end up indexed but invisible to FTS search.

The MCP-write path and the `/local/upload` route work correctly — they chunk explicitly. The 654ab03 fix ("Made wiki pages searchable with keyword search") covered the analogous gap on the MCP-write side. This PR closes the filesystem watcher side of the same problem.

## Fix

Extract a `_chunk_text_file` helper and call it from both branches of `_index_file` (create + update) for files in `TEXT_EXTENSIONS`. The helper:
- Deletes any existing chunks for the document (so re-indexes stay in sync)
- Calls the existing `services.chunker.chunk_text`
- Inserts into `document_chunks`

The existing FTS5 triggers on `document_chunks` keep `chunks_fts` in sync automatically — no extra work needed.

## Reproduce on `master`

```bash
./llmwiki init /tmp/wiki-repro
./llmwiki serve /tmp/wiki-repro &
echo "anxious attachment is a deactivation pattern" > /tmp/wiki-repro/notes.md
sleep 3
sqlite3 /tmp/wiki-repro/.llmwiki/index.db \
  "SELECT count(*) FROM document_chunks dc JOIN documents d ON dc.document_id=d.id WHERE d.filename='notes.md';"
# → 0 (bug)
```

Repeat with this branch → 1 chunk.

## Empirical evidence from a real workspace

| file_type | total docs | with content | 0 chunks |
|-----------|-----------|--------------|----------|
| md        | 887       | 887          | **310**  |
| txt       | 142       | 141          | **60**   |

(The non-zero chunked .md/.txt are ones I retroactively chunked with a workaround script before realizing this was a fixable upstream gap.)

## Scope notes

- HTML is in `TEXT_EXTENSIONS` so gets chunked here as raw HTML. `_process_html` in `local_processor.py` does proper nav/ad stripping via webmd but is never triggered by the watcher (same `status='pending'` gate). Routing HTML there is a separate improvement — kept out of this PR to keep the change minimal and focused on the reported bug.
- No new dependencies, no schema change, no public API change.
- Existing tests untouched (I haven't added a watcher integration test — happy to if you'd like).