### PR TITLE
init: honor .llmwikiignore / .gitignore patterns during workspace scan

### DIFF
--- a/llmwiki
+++ b/llmwiki
@@ -111,6 +111,41 @@ def cmd_init(workspace: str) -> None:
     print(f"  .llmwiki/index.db — created")
 
 
+def _load_init_ignore_patterns(ws: Path) -> list:
+    """Load .llmwikiignore (or .gitignore as fallback) patterns for init walk.
+
+    Mirrors api/domain/watcher.py:_load_ignore_patterns so that init and watch
+    apply the same exclusion rules. Without this, files dropped into the
+    workspace before the first `llmwiki serve` get indexed regardless of
+    ignore rules.
+    """
+    patterns = []
+    for ignore_file in (".llmwikiignore", ".gitignore"):
+        p = ws / ignore_file
+        if p.is_file():
+            for line in p.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    patterns.append(line)
+            break  # use first found, don't merge
+    return patterns
+
+
+def _matches_init_ignore(relative: str, patterns: list) -> bool:
+    """Gitignore-style matching for init walk. Mirrors watcher.py logic."""
+    from fnmatch import fnmatch
+    for pattern in patterns:
+        pattern = pattern.rstrip("/")
+        if fnmatch(relative, pattern):
+            return True
+        if fnmatch(relative, f"**/{pattern}"):
+            return True
+        for part in relative.split("/"):
+            if fnmatch(part, pattern):
+                return True
+    return False
+
+
 def _index_existing_files(ws: Path, db_path: Path, user_id: str, ws_id: str) -> None:
     """Index existing files in the workspace into SQLite."""
     import hashlib
@@ -118,7 +153,9 @@ def _index_existing_files(ws: Path, db_path: Path, user_id: str, ws_id: str) -> 
     import sqlite3
 
     ignore_dirs = {".llmwiki", ".git", "node_modules", "__pycache__", ".venv", "venv"}
+    user_patterns = _load_init_ignore_patterns(ws)
     indexed = 0
+    skipped_ignored = 0
 
     conn = sqlite3.connect(str(db_path))
 
@@ -127,8 +164,18 @@ def _index_existing_files(ws: Path, db_path: Path, user_id: str, ws_id: str) -> 
     existing = {row[0] for row in cursor.fetchall()}
 
     for root_path, dirs, files in os.walk(ws):
-        # Skip ignored directories
+        # Skip ignored directories (built-in)
         dirs[:] = [d for d in dirs if d not in ignore_dirs and not d.startswith(".")]
+        # Skip directories matched by user ignore patterns
+        if user_patterns:
+            kept = []
+            for d in dirs:
+                dir_rel = str((Path(root_path) / d).relative_to(ws))
+                if _matches_init_ignore(dir_rel, user_patterns):
+                    skipped_ignored += 1
+                    continue
+                kept.append(d)
+            dirs[:] = kept
 
         for filename in files:
             if filename.startswith("."):
@@ -138,6 +185,11 @@ def _index_existing_files(ws: Path, db_path: Path, user_id: str, ws_id: str) -> 
             relative = str(full.relative_to(ws))
 
             if relative in existing:
+                continue
+
+            # Apply user ignore patterns (file-level)
+            if user_patterns and _matches_init_ignore(relative, user_patterns):
+                skipped_ignored += 1
                 continue
 
             ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
@@ -187,6 +239,8 @@ def _index_existing_files(ws: Path, db_path: Path, user_id: str, ws_id: str) -> 
 
     if indexed > 0:
         print(f"✓ Indexed {indexed} existing file(s)")
+    if skipped_ignored > 0:
+        print(f"  (skipped {skipped_ignored} path(s) matched by .llmwikiignore/.gitignore)")
 
 
 def cmd_serve(workspace: str, open_browser: bool = True) -> None:


### PR DESCRIPTION
## Problem

`cmd_init` → `_index_existing_files` walks the workspace using only a hardcoded `ignore_dirs` set (`{.llmwiki, .git, node_modules, __pycache__, .venv, venv}`) plus a leading-dot filter. It does **not** load `.llmwikiignore` or `.gitignore`.

This diverges from the watcher, which **does** honor those files (`api/domain/watcher.py:_load_ignore_patterns` + `_matches_ignore_pattern`).

Effect: any files dropped into the workspace **before the first `llmwiki serve`** get indexed regardless of the user's ignore rules. Once `serve` starts, the watcher correctly filters new events — but the init-time pollution is already in `documents`, surfaces in FTS results, and bloats the workspace.

## Reproduce on `master`

```bash
mkdir -p /tmp/repro/{keep,skip}
echo 'skip/' > /tmp/repro/.llmwikiignore
echo 'keep me' > /tmp/repro/keep/keep.md
echo 'skip me' > /tmp/repro/skip/skip.md
./llmwiki init /tmp/repro
sqlite3 /tmp/repro/.llmwiki/index.db 'SELECT relative_path FROM documents'
```

**On master:**
```
keep/keep.md
skip/skip.md         ← bug: should be excluded
wiki/log.md
wiki/overview.md
```

**With this PR:**
```
✓ Indexed 1 existing file(s)
  (skipped 1 path(s) matched by .llmwikiignore/.gitignore)

keep/keep.md
wiki/log.md
wiki/overview.md
```

## Empirical evidence from a real workspace

For our workspace (where `.llmwikiignore` excludes `love-llmwiki/raw/`, `resources/`, `logs/`, `tooling/`, and several binary file types), running `llmwiki init` on master indexed **2,549 documents**, of which **1,778 were paths the `.llmwikiignore` explicitly excluded**. They had to be hand-cleaned out of `documents` before the workspace was usable. With this PR they would never have been added.

## Fix

Extract two helpers in `llmwiki` that mirror the watcher's logic:

- `_load_init_ignore_patterns(ws)` — loads `.llmwikiignore` (falls back to `.gitignore`), skips blank lines and `#` comments
- `_matches_init_ignore(relative, patterns)` — `fnmatch`-based gitignore-style matching

Apply them in `_index_existing_files`'s `os.walk` at both levels:
- **directory level** — prune ignored subtrees so we don't walk into `love-llmwiki/raw/4GB-of-audio/`
- **file level** — skip individual leaves matched by glob patterns like `*.mp3` or `*.log`

Also adds a `skipped_ignored` counter, printed alongside the existing `Indexed N` summary.

## Why duplicate rather than import?

`llmwiki` (the root CLI script) and `api/domain/watcher.py` live in different Python module trees. Importing watcher's helpers requires adding `api/` to `sys.path` from the CLI script, which feels heavier than the two ~10-line helpers. Happy to refactor to a shared module if you'd prefer that.

## Scope notes

- Pure addition. No behavior change for users without `.llmwikiignore` or `.gitignore`.
- Output now includes the `(skipped N path(s)...)` line when patterns matched anything — minor UX improvement that helps users notice when their ignore rules are working.
- Does not touch the watcher; this is purely a parity fix for the init code path.
- Related but distinct from #47/#48 (chunker gap for filesystem-added TEXT files). Both bugs affect "files dropped into a workspace before-or-without serve."