### PR TITLE
Fix sqlite schema in local mode (Adding kb_id)

### DIFF
--- a/api/infra/db/sqlite.py
+++ b/api/infra/db/sqlite.py
@@ -103,7 +103,7 @@ class SQLiteDocumentRepository:
     ) -> dict | None:
         cursor = await self._db.execute(
             "SELECT * FROM documents WHERE knowledge_base_id = ? AND user_id = ? "
-            "AND filename = ? AND path = ? AND NOT archived",
+            "AND filename = ? AND path = ?", # AND NOT archived
             (kb_id, user_id, filename, path),
         )
         row = await cursor.fetchone()
@@ -124,12 +124,13 @@ class SQLiteDocumentRepository:
         doc_number = row[0]
 
         await self._db.execute(
-            "INSERT INTO documents (id, user_id, filename, title, path, relative_path, source_kind, "
+            "INSERT INTO documents (id, knowledge_base_id, user_id, filename, title, path, relative_path, source_kind, "
             "file_type, status, content, tags, version, document_number) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, 'md', 'ready', ?, ?, 0, ?)",
-            (doc_id, user_id, filename, title, path, relative_path, source_kind,
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'md', 'ready', ?, ?, 0, ?)",
+            (doc_id, kb_id, user_id, filename, title, path, relative_path, source_kind,
              content, json.dumps(tags), doc_number),
         )
+        print("SAAAAAAAAAAAAAAAA")
         await self._db.commit()
         return await self.get(doc_id)
 

--- a/api/infra/db/sqlite_schema.sql
+++ b/api/infra/db/sqlite_schema.sql
@@ -1,0 +1,106 @@
+-- LLM Wiki local index schema (SQLite + FTS5)
+-- This is derived state — deletable and rebuildable from the workspace filesystem.
+
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS workspace (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    user_id TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    UNIQUE(user_id)
+);
+
+CREATE TABLE IF NOT EXISTS documents (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    knowledge_base_id TEXT NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    title TEXT,
+    path TEXT DEFAULT '/' NOT NULL,
+    relative_path TEXT NOT NULL,
+    source_kind TEXT NOT NULL CHECK (source_kind IN ('wiki', 'source', 'asset')),
+    file_type TEXT NOT NULL,
+    file_size INTEGER DEFAULT 0,
+    document_number INTEGER,
+    status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'ready', 'failed')),
+    page_count INTEGER,
+    content TEXT,
+    tags TEXT DEFAULT '[]',
+    date TEXT,
+    metadata TEXT,
+    error_message TEXT,
+    version INTEGER DEFAULT 0,
+    parser TEXT,
+    content_hash TEXT,
+    mtime_ns INTEGER,
+    last_indexed_at TEXT,
+    stale_since TEXT,
+    highlights TEXT DEFAULT '[]',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    UNIQUE(relative_path)
+);
+
+CREATE TABLE IF NOT EXISTS document_pages (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    page INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    elements TEXT,
+    UNIQUE(document_id, page)
+);
+
+CREATE TABLE IF NOT EXISTS document_chunks (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    chunk_index INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    page INTEGER,
+    start_char INTEGER,
+    token_count INTEGER NOT NULL,
+    header_breadcrumb TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    UNIQUE(document_id, chunk_index)
+);
+
+CREATE TABLE IF NOT EXISTS document_references (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    source_document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    target_document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    reference_type TEXT NOT NULL CHECK (reference_type IN ('cites', 'links_to')),
+    page INTEGER,
+    UNIQUE(source_document_id, target_document_id, reference_type)
+);
+
+-- FTS5 full-text search (replaces pgroonga)
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+    content,
+    content='document_chunks',
+    content_rowid='rowid',
+    tokenize='porter unicode61'
+);
+
+-- Keep FTS in sync with document_chunks
+CREATE TRIGGER IF NOT EXISTS chunks_fts_insert AFTER INSERT ON document_chunks BEGIN
+    INSERT INTO chunks_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS chunks_fts_delete AFTER DELETE ON document_chunks BEGIN
+    INSERT INTO chunks_fts(chunks_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS chunks_fts_update AFTER UPDATE ON document_chunks BEGIN
+    INSERT INTO chunks_fts(chunks_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+    INSERT INTO chunks_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE INDEX IF NOT EXISTS idx_documents_relative_path ON documents(relative_path);
+CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path);
+CREATE INDEX IF NOT EXISTS idx_documents_source_kind ON documents(source_kind);
+CREATE INDEX IF NOT EXISTS idx_documents_status ON documents(status);
+CREATE INDEX IF NOT EXISTS idx_chunks_doc ON document_chunks(document_id);
+CREATE INDEX IF NOT EXISTS idx_refs_source ON document_references(source_document_id);
+CREATE INDEX IF NOT EXISTS idx_refs_target ON document_references(target_document_id);

--- a/api/routes/local_upload.py
+++ b/api/routes/local_upload.py
@@ -67,7 +67,7 @@ async def upload_file(
             text_content = content_bytes.decode("utf-8", errors="replace")
         except Exception:
             pass
-
+    
     # Index into SQLite
     from infra.db.sqlite import SQLiteDocumentRepository, SQLiteChunkRepository
     db = request.app.state.sqlite_db
@@ -81,13 +81,16 @@ async def upload_file(
     row = await cursor.fetchone()
     doc_number = row[0]
 
+    ws_row = await db.execute("SELECT id FROM workspace LIMIT 1")
+    ws = await ws_row.fetchone()
+    kb_id = ws[0] if ws else ""
     import json
     await db.execute(
-        "INSERT INTO documents (id, user_id, filename, title, path, relative_path, "
+        "INSERT INTO documents (id, knowledge_base_id, user_id, filename, title, path, relative_path, "
         "source_kind, file_type, file_size, status, content, tags, version, "
         "content_hash, mtime_ns, last_indexed_at, document_number) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', 0, ?, ?, datetime('now'), ?)",
-        (doc_id, user_id, filename, title, dir_path, relative, source_kind,
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', 0, ?, ?, datetime('now'), ?)",
+        (doc_id, kb_id, user_id, filename, title, dir_path, relative, source_kind,
          ext or "bin", len(content_bytes),
          "ready" if text_content is not None else "pending",
          text_content, content_hash,

--- a/api/services/local.py
+++ b/api/services/local.py
@@ -189,7 +189,7 @@ class LocalDocumentService(DocumentService):
         file_path.write_text(content or "", encoding="utf-8")
 
         row = await self.doc_repo.create_note(kb_id, self.user_id, filename, path, title, content, tags)
-
+        
         if content:
             chunks = chunk_text(content)
             await self.chunk_repo.store(str(row["id"]), self.user_id, kb_id, chunks)

--- a/llmwiki
+++ b/llmwiki
@@ -69,21 +69,21 @@ def cmd_init(workspace: str) -> None:
     # Scaffold wiki pages
     doc1_id = str(uuid.uuid4())
     conn.execute(
-        "INSERT INTO documents (id, user_id, filename, title, path, relative_path, source_kind, "
+        "INSERT INTO documents (id, knowledge_base_id, user_id, filename, title, path, relative_path, source_kind, "
         "file_type, status, content, tags, version, document_number) "
-        "VALUES (?, ?, 'overview.md', 'Overview', '/wiki/', 'wiki/overview.md', 'wiki', "
+        "VALUES (?, ?, ?, 'overview.md', 'Overview', '/wiki/', 'wiki/overview.md', 'wiki', "
         "'md', 'ready', ?, '[]', 0, 1)",
-        (doc1_id, user_id,
+        (doc1_id, ws_id, user_id,
          f"This wiki tracks research on {ws_name}.\n\n## Key Findings\n\nNo sources ingested yet.\n\n## Recent Updates\n\nNo activity yet."),
     )
 
     doc2_id = str(uuid.uuid4())
     conn.execute(
-        "INSERT INTO documents (id, user_id, filename, title, path, relative_path, source_kind, "
+        "INSERT INTO documents (id, knowledge_base_id, user_id, filename, title, path, relative_path, source_kind, "
         "file_type, status, content, tags, version, document_number) "
-        "VALUES (?, ?, 'log.md', 'Log', '/wiki/', 'wiki/log.md', 'wiki', "
+        "VALUES (?, ?, ?, 'log.md', 'Log', '/wiki/', 'wiki/log.md', 'wiki', "
         "'md', 'ready', ?, '[]', 0, 2)",
-        (doc2_id, user_id, "Chronological record of ingests, queries, and maintenance passes."),
+        (doc2_id, ws_id, user_id, "Chronological record of ingests, queries, and maintenance passes."),
     )
 
     conn.commit()
@@ -169,12 +169,12 @@ def _index_existing_files(ws: Path, db_path: Path, user_id: str, ws_id: str) -> 
 
             try:
                 conn.execute(
-                    "INSERT INTO documents (id, user_id, filename, title, path, relative_path, "
+                    "INSERT INTO documents (id, knowledge_base_id, user_id, filename, title, path, relative_path, "
                     "source_kind, file_type, file_size, status, content, tags, version, "
                     "content_hash, mtime_ns, last_indexed_at, document_number) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'ready', ?, '[]', 0, ?, ?, datetime('now'), "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ready', ?, '[]', 0, ?, ?, datetime('now'), "
                     "(SELECT COALESCE(MAX(document_number), 0) + 1 FROM documents))",
-                    (doc_id, user_id, filename, title, dir_path, relative,
+                    (doc_id, ws_id, user_id, filename, title, dir_path, relative,
                      source_kind, ext or "bin", stat.st_size, content,
                      content_hash, int(stat.st_mtime_ns)),
                 )
@@ -210,7 +210,7 @@ def cmd_serve(workspace: str, open_browser: bool = True) -> None:
 
     # Start API server
     api_proc = subprocess.Popen(
-        [sys.executable, "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"],
+        [sys.executable, "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"],
         cwd=str(API_DIR),
         env=env,
     )


### PR DESCRIPTION
Local SQLite schema was missing `knowledge_base_id`, which caused document lookup and upload failures for md and txt files when running in local mode.

This change adds `knowledge_base_id` to the SQLite `documents` table to align it with the Postgres schema used in production.

Fixes upload/query crashes (especially for `.txt` files) and restores compatibility with `find_by_path` and related queries.

Tested locally with PDF, md, and txt uploads.