### PR TITLE
Decode jsonb metadata in hosted responses; final snapback guard

### DIFF
--- a/api/services/hosted.py
+++ b/api/services/hosted.py
@@ -286,6 +286,14 @@ _DOC_COLUMNS = (
     "version, document_number, archived, created_at, updated_at"
 )
 
+
+def _doc_dict(row) -> dict:
+    """asyncpg returns jsonb as str — decode metadata so responses carry an object."""
+    doc = dict(row)
+    if isinstance(doc.get("metadata"), str):
+        doc["metadata"] = json.loads(doc["metadata"])
+    return doc
+
 _WEBCLIP_ROOT = "/webclipper/"
 
 
@@ -349,14 +357,14 @@ class HostedDocumentService(DocumentService):
                 "ORDER BY filename",
                 kb_id, self.user_id,
             )
-        return [dict(r) for r in rows]
+        return [_doc_dict(r) for r in rows]
 
     async def get(self, doc_id: str) -> dict | None:
         row = await self.pool.fetchrow(
             f"SELECT {_DOC_COLUMNS} FROM documents WHERE id = $1 AND user_id = $2",
             doc_id, self.user_id,
         )
-        return dict(row) if row else None
+        return _doc_dict(row) if row else None
 
     async def get_content(self, doc_id: str) -> dict | None:
         row = await self.pool.fetchrow(
@@ -415,7 +423,7 @@ class HostedDocumentService(DocumentService):
                     await store_chunks(conn, str(row["id"]), self.user_id, str(kb_id), chunks)
         finally:
             await self.pool.release(conn)
-        return dict(row)
+        return _doc_dict(row)
 
     async def create_web_clip(
         self, kb_id: str, url: str, title: str, html: str,
@@ -574,7 +582,7 @@ class HostedDocumentService(DocumentService):
 
         await self._purge_s3(old_asset_ids)
 
-        response = dict(row)
+        response = _doc_dict(row)
         response["highlights"] = next_highlights
         return response
 
@@ -1056,13 +1064,13 @@ class HostedDocumentService(DocumentService):
                     )
             finally:
                 await self.pool.release(conn)
-            return dict(row)
+            return _doc_dict(row)
 
         try:
             row = await self.pool.fetchrow(sql, *params)
         except asyncpg.UniqueViolationError as e:
             self._reraise_doc_conflict(e)
-        return dict(row) if row else None
+        return _doc_dict(row) if row else None
 
     async def delete(self, doc_id: str) -> bool:
         # Wiki pages are archived to preserve slugs and cross-references;

--- a/tests/integration/test_note_lifecycle.py
+++ b/tests/integration/test_note_lifecycle.py
@@ -204,6 +204,57 @@ class TestUpdateMetadata:
         assert resp.json()["title"] == "New Title"
         assert resp.json()["tags"] == ["important", "v2"]
 
+    async def test_metadata_round_trips_as_object(self, client):
+        headers = auth_headers(USER_ID)
+        create_resp = await client.post(
+            f"/v1/knowledge-bases/{KB_ID}/documents/note",
+            headers=headers,
+            json={"filename": "progress.md", "content": "x " * 70},
+        )
+        doc_id = create_resp.json()["id"]
+
+        course = {"status": "complete", "completed_at": "2026-07-07T00:00:00Z"}
+        patch_resp = await client.patch(
+            f"/v1/documents/{doc_id}",
+            headers=headers,
+            json={"metadata": {"course": course}},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["metadata"] == {"course": course}
+
+        list_resp = await client.get(
+            f"/v1/knowledge-bases/{KB_ID}/documents", headers=headers,
+        )
+        listed = next(d for d in list_resp.json() if d["id"] == doc_id)
+        assert listed["metadata"] == {"course": course}
+
+        get_resp = await client.get(f"/v1/documents/{doc_id}", headers=headers)
+        assert get_resp.json()["metadata"] == {"course": course}
+
+    async def test_metadata_patch_merges_top_level_keys(self, client):
+        headers = auth_headers(USER_ID)
+        create_resp = await client.post(
+            f"/v1/knowledge-bases/{KB_ID}/documents/note",
+            headers=headers,
+            json={"filename": "merge.md", "content": "x " * 70},
+        )
+        doc_id = create_resp.json()["id"]
+
+        await client.patch(
+            f"/v1/documents/{doc_id}",
+            headers=headers,
+            json={"metadata": {"source_url": "https://example.com"}},
+        )
+        resp = await client.patch(
+            f"/v1/documents/{doc_id}",
+            headers=headers,
+            json={"metadata": {"course": {"status": "complete"}}},
+        )
+        assert resp.json()["metadata"] == {
+            "source_url": "https://example.com",
+            "course": {"status": "complete"},
+        }
+
     async def test_empty_patch_rejected(self, client):
         headers = auth_headers(USER_ID)
         create_resp = await client.post(

--- a/web/src/components/kb/WikiOnlyDetail.tsx
+++ b/web/src/components/kb/WikiOnlyDetail.tsx
@@ -145,10 +145,13 @@ export function WikiOnlyDetail({
 
   // Applies ?p= to the active path exactly once per URL value (deep links, back/forward).
   // `documents` churns constantly (WS/poll, optimistic course-progress writes) — re-running
-  // on churn would re-assert a stale URL and snap in-app navigation back.
+  // on churn would re-assert a stale URL and snap in-app navigation back. useSearchParams
+  // also lags our own history.replaceState writes, so a churn-triggered run can observe the
+  // pre-navigation ?p= — trust only values that match the live URL.
   React.useEffect(() => {
     if (urlWikiDocNumber == null || !documents.length) return
     if (urlWikiDocNumber === handledUrlDocNumberRef.current) return
+    if (new URL(window.location.href).searchParams.get('p') !== String(urlWikiDocNumber)) return
     const doc = documents.find((d) => d.document_number === urlWikiDocNumber)
     if (!doc) return
     handledUrlDocNumberRef.current = urlWikiDocNumber


### PR DESCRIPTION
Commits the last three working-tree fixes that missed #70: `_doc_dict` (course progress on hosted), the live-URL snapback guard in WikiOnlyDetail, and metadata round-trip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)